### PR TITLE
Feat: Prevent to open link when selecting image/video checkbox

### DIFF
--- a/apps/portal/components/pagesComponents/_imagesScreen/pages/myVideos/VideoItem/VideoItem.tsx
+++ b/apps/portal/components/pagesComponents/_imagesScreen/pages/myVideos/VideoItem/VideoItem.tsx
@@ -86,6 +86,8 @@ const VideoItem: FC<IVideoItemProps> = ({
     false;
 
   const selectItem = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
     if (addSelected && video && selectedItems) {
       const selected = isSelected;
       const newItems = selected
@@ -153,7 +155,6 @@ const VideoItem: FC<IVideoItemProps> = ({
               <img src={video?.url} alt="" />
             </div>
           )}
-
           <Overlay
             onRestoreFromTrash={onRestoreFromTrash}
             addSelected={addSelected}


### PR DESCRIPTION
Now working multi-select without opening link
![image](https://github.com/user-attachments/assets/5634451a-37fe-4e57-8787-65761fbb0bf8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved video selection interactions by refining click event behavior to prevent unintended actions during selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->