### PR TITLE
[Build] - Web: Error on language import path.

### DIFF
--- a/apps/portal/components/shared/SCHeader/SCHeader.tsx
+++ b/apps/portal/components/shared/SCHeader/SCHeader.tsx
@@ -15,7 +15,8 @@ import PanelAC from 'app/store/panel/actions/PanelAC';
 import { signOut } from 'app/services/auth';
 import { Dispatch } from 'redux';
 import { infoMessage } from 'app/services/helpers/toastMessages';
-import { languages } from 'i18n/constants';
+import { languages } from '../../../i18n/constants';
+
 import { useTranslation } from 'react-i18next';
 
 interface ISCHeaderProps {


### PR DESCRIPTION
Instead of using this route.
`import { languages } from 'i18n/constants';`

This route path is changed to fix build issue. 
`import { languages } from '../../../i18n/constants';`
