### PR TITLE
[Fix(auth)] Use updated refresh token from gauzy service

### DIFF
--- a/apps/api/src/module/auth/services/tokens/refresh/gauzy-refresh.strategy.ts
+++ b/apps/api/src/module/auth/services/tokens/refresh/gauzy-refresh.strategy.ts
@@ -24,7 +24,7 @@ export class GauzyRefreshStrategy extends RefreshStrategyState {
   }
 
   async handle({ result }: IRefreshTokenContext, refreshToken: string): Promise<RefreshResponse> {
-    const { data: { token } } = await this.gauzyAuthService.refreshToken(refreshToken);
+    const { data: { token, refresh_token } } = await this.gauzyAuthService.refreshToken(refreshToken);
 
     this.validateResponse(token);
 
@@ -33,13 +33,13 @@ export class GauzyRefreshStrategy extends RefreshStrategyState {
 
     const response = {
       idToken: token,
-      refreshToken,
+      refreshToken: refresh_token,
       expiresAt,
     };
 
     result.set(this.providerId, {
       accessToken: token,
-      refreshToken,
+      refreshToken: refresh_token,
       data: response
     });
 

--- a/apps/api/src/module/auth/services/tokens/refresh/gauzy-refresh.strategy.ts
+++ b/apps/api/src/module/auth/services/tokens/refresh/gauzy-refresh.strategy.ts
@@ -27,6 +27,7 @@ export class GauzyRefreshStrategy extends RefreshStrategyState {
     const { data: { token, refresh_token } } = await this.gauzyAuthService.refreshToken(refreshToken);
 
     this.validateResponse(token);
+    this.validateResponse(refresh_token);
 
     const expiresIn = 3000;
     const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();

--- a/apps/api/src/module/gauzy/services/gauzy-auth.service.ts
+++ b/apps/api/src/module/gauzy/services/gauzy-auth.service.ts
@@ -22,7 +22,7 @@ export class GauzyAuthService {
   }
 
   public async refreshToken(value: string) {
-    return this.gauzyRestService.post<{ refresh_token: string }, { token: string }>('auth/refresh-token', { refresh_token: value });
+    return this.gauzyRestService.post<{ refresh_token: string }, { token: string, refresh_token: string }>('auth/refresh-token', { refresh_token: value });
   }
 
   public async requestPassword(email: string) {


### PR DESCRIPTION
Update GauzyRefreshStrategy to extract and use the new refresh_token returned by the Gauzy authentication service. This ensures the system uses the most recent refresh token provided by the API instead of reusing the old one.

## Description

Please include a summary of the changes and the related issues.

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots

Please add here videos or images of the previous status

## Current screenshots

Please add here videos or images of the current (new) status

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the new refresh_token from the Gauzy auth API and validate it before use. Prevents session loss after rotation and catches bad refresh responses.

- **Bug Fixes**
  - Return and consume { token, refresh_token }; propagate the new refresh_token.
  - Validate refresh_token in GauzyRefreshStrategy to reject invalid/missing values.

<sup>Written for commit df007d1c1f212451fa11cb583eda85e631ce2940. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

