### PR TITLE
ci: route runners to self-hosted ARC pools

### DIFF
--- a/.github/workflows/docker-build-publish-api-dev.yaml
+++ b/.github/workflows/docker-build-publish-api-dev.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   ever-rec-api:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
 
     environment: dev
 

--- a/.github/workflows/docker-build-publish-api.yaml
+++ b/.github/workflows/docker-build-publish-api.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   ever-rec-api:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
 
     environment: prod
 

--- a/.github/workflows/docker-build-publish-portal-dev.yaml
+++ b/.github/workflows/docker-build-publish-portal-dev.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   ever-rec-portal:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
 
     environment: dev
 

--- a/.github/workflows/docker-build-publish-portal.yaml
+++ b/.github/workflows/docker-build-publish-portal.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   ever-rec-portal:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
 
     environment: prod
 


### PR DESCRIPTION
Routes the four Docker image build workflows off the broken `buildjet-8vcpu-ubuntu-2204` runner onto our self-hosted ARC pools, unblocking stuck / off-policy CI.

Each is a heavy Docker image build job, so it moves to the `_8` (8-vCPU) ARC pool:

- `docker-build-publish-api.yaml` (`ever-rec-api`, prod) — `buildjet-8vcpu-ubuntu-2204` → `${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}`
- `docker-build-publish-api-dev.yaml` (`ever-rec-api`, dev) — `buildjet-8vcpu-ubuntu-2204` → `${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}`
- `docker-build-publish-portal.yaml` (`ever-rec-portal`, prod) — `buildjet-8vcpu-ubuntu-2204` → `${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}`
- `docker-build-publish-portal-dev.yaml` (`ever-rec-portal`, dev) — `buildjet-8vcpu-ubuntu-2204` → `${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}`

`|| 'ubuntu-latest'` fallback preserves fork/CI safety. No other files touched; `deploy-do-*.yml` left untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route the four Docker image build workflows from the broken `buildjet-8vcpu-ubuntu-2204` runner to our self-hosted ARC 8‑vCPU pool via `vars.RUNNER_LINUX_X64_8`, unblocking CI. Adds a safe fallback to `ubuntu-latest`; deploy workflows are unchanged.

<sup>Written for commit ca297f0c24aac121fed6ebcd75bd973dfb44cc9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-rec/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

