### PR TITLE
ci: gate DigitalOcean registry push behind DO_ENABLED (account locked, 403s every build)

### DIFF
--- a/.github/workflows/docker-build-publish-api-dev.yaml
+++ b/.github/workflows/docker-build-publish-api-dev.yaml
@@ -50,14 +50,17 @@ jobs:
           docker push everco/ever-rec-api-dev:latest
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-rec-api-dev:latest
 

--- a/.github/workflows/docker-build-publish-api.yaml
+++ b/.github/workflows/docker-build-publish-api.yaml
@@ -50,14 +50,17 @@ jobs:
           docker push everco/ever-rec-api:latest
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-rec-api:latest
 

--- a/.github/workflows/docker-build-publish-portal-dev.yaml
+++ b/.github/workflows/docker-build-publish-portal-dev.yaml
@@ -58,14 +58,17 @@ jobs:
           docker push everco/ever-rec-portal-dev:latest
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-rec-portal-dev:latest
 

--- a/.github/workflows/docker-build-publish-portal.yaml
+++ b/.github/workflows/docker-build-publish-portal.yaml
@@ -58,14 +58,17 @@ jobs:
           docker push everco/ever-rec-portal:latest
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-rec-portal:latest
 


### PR DESCRIPTION
All 4 docker image build workflows succeed at building but fail at the final DigitalOcean registry push with 403 Forbidden (the DO account is locked).

Per the no-removal rule, the legacy steps are **gated, not removed**: added `if: ${{ vars.DO_ENABLED == 'true' }}` to the 3 DO steps (Install doctl / DO registry login / Push to DigitalOcean Registry) in each of:

- .github/workflows/docker-build-publish-api.yaml
- .github/workflows/docker-build-publish-api-dev.yaml
- .github/workflows/docker-build-publish-portal.yaml
- .github/workflows/docker-build-publish-portal-dev.yaml

GHCR, Docker Hub, and build steps are untouched. Re-enable anytime by setting org/repo variable `DO_ENABLED=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated DigitalOcean Container Registry steps in all Docker image workflows behind `vars.DO_ENABLED` to stop 403 failures from the locked DO account. Build, GHCR, and Docker Hub pushes are unaffected.

- **Bug Fixes**
  - Added `if: ${{ vars.DO_ENABLED == 'true' }}` to the three DO steps (install `digitalocean/action-doctl@v2`, registry login, push) in the API and Portal workflows (prod and dev).

- **Migration**
  - To re-enable DO pushes, set the org/repo variable `DO_ENABLED=true`.

<sup>Written for commit c12cc6120eefc8602b7c09e2b51ddbac9b0ff2ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-rec/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

